### PR TITLE
Fix for  KitKat not enabling TLS v1.2 by default

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.3.0'
     // jsoup HTML parser library @ http://jsoup.org/
     compile 'org.jsoup:jsoup:1.9.2'
+    compile 'com.google.android.gms:play-services:6.1.+'
     compile 'com.google.code.gson:gson:2.2.4'
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
         <activity android:name=".FindBeerActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/ghost/dmac/beeradviser/DisplayBeer.java
+++ b/app/src/main/java/com/ghost/dmac/beeradviser/DisplayBeer.java
@@ -12,6 +12,11 @@ import org.jsoup.Jsoup;
 import org.jsoup.helper.StringUtil;
 import org.jsoup.nodes.Document;
 import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 
 
 public class DisplayBeer extends AppCompatActivity {
@@ -55,16 +60,24 @@ public class DisplayBeer extends AppCompatActivity {
 
                     String useragent = System.getProperty("http.agent");
 
+
+
+                   try {
+                       HttpsURLConnection.setDefaultSSLSocketFactory(new TLSSocketFactory());
+                   } catch(KeyManagementException | NoSuchAlgorithmException e) {
+                       e.printStackTrace();
+                   }
+
                     Connection.Response loginForm = Jsoup.connect(url)
                             .data("username", userText)
                             .data("password", passText)
                             .data("op", "Log+in")
                             .data("form_id", "custom_login_form")
                             .userAgent(useragent)
+                            .validateTLSCertificates(false)
                             .method(Connection.Method.POST)
                             .timeout(6000)
                             .execute();
-
 
                     Document log = Jsoup.connect(url)
                             .cookies(loginForm.cookies())

--- a/app/src/main/java/com/ghost/dmac/beeradviser/FindBeerActivity.java
+++ b/app/src/main/java/com/ghost/dmac/beeradviser/FindBeerActivity.java
@@ -9,6 +9,11 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+
+import java.security.AccessController;
+
 
 public class FindBeerActivity extends AppCompatActivity {
     public static final String MyPREFERENCES = "MyPrefs";
@@ -18,6 +23,15 @@ public class FindBeerActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        try {
+            com.google.android.gms.security.ProviderInstaller.installIfNeeded(getApplicationContext());
+        } catch (GooglePlayServicesRepairableException e) {
+            e.printStackTrace();
+        } catch (GooglePlayServicesNotAvailableException e) {
+            e.printStackTrace();
+        }
+
         setContentView(R.layout.activity_find_beer);
         SharedPreferences ntest = getSharedPreferences(MyPREFERENCES, Context.MODE_PRIVATE);
         String newid = ntest.getString(userid, userNum);

--- a/app/src/main/java/com/ghost/dmac/beeradviser/TLSSocketFactory.java
+++ b/app/src/main/java/com/ghost/dmac/beeradviser/TLSSocketFactory.java
@@ -1,0 +1,68 @@
+package com.ghost.dmac.beeradviser;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * @author fkrauthan
+ */
+public class TLSSocketFactory extends SSLSocketFactory {
+
+    private SSLSocketFactory internalSSLSocketFactory;
+
+    public TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, null, null);
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return internalSSLSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return internalSSLSocketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket enableTLSOnSocket(Socket socket) {
+        if(socket != null && (socket instanceof SSLSocket)) {
+            ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.1", "TLSv1.2"});
+        }
+        return socket;
+    }
+}


### PR DESCRIPTION
https://developer.android.com/training/articles/security-gms-provider.html
http://stackoverflow.com/questions/24357863/making-sslengine-use-tlsv1-2-on-android-4-4-2
